### PR TITLE
Nprigour upgrade to geotools 19.0

### DIFF
--- a/plugins/org.locationtech.udig.bookmarks.tests/pom.xml
+++ b/plugins/org.locationtech.udig.bookmarks.tests/pom.xml
@@ -20,8 +20,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
              </plugin>
 

--- a/plugins/org.locationtech.udig.catalog.tests.geotiff/pom.xml
+++ b/plugins/org.locationtech.udig.catalog.tests.geotiff/pom.xml
@@ -20,7 +20,6 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
                    <application>org.locationtech.udig.ui.application</application>
                    <showEclipseLog>true</showEclipseLog>
                 </configuration>

--- a/plugins/org.locationtech.udig.catalog.tests.ui/pom.xml
+++ b/plugins/org.locationtech.udig.catalog.tests.ui/pom.xml
@@ -20,8 +20,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
             </plugin>
 

--- a/plugins/org.locationtech.udig.catalog.tests.wfs/pom.xml
+++ b/plugins/org.locationtech.udig.catalog.tests.wfs/pom.xml
@@ -19,8 +19,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
             </plugin>
 

--- a/plugins/org.locationtech.udig.catalog.tests.wms/pom.xml
+++ b/plugins/org.locationtech.udig.catalog.tests.wms/pom.xml
@@ -20,8 +20,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
             </plugin>
 

--- a/plugins/org.locationtech.udig.catalog.tests/pom.xml
+++ b/plugins/org.locationtech.udig.catalog.tests/pom.xml
@@ -17,8 +17,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
             </plugin>
 

--- a/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/util/CatalogTestUtils.java
+++ b/plugins/org.locationtech.udig.catalog.tests/src/org/locationtech/udig/catalog/util/CatalogTestUtils.java
@@ -1,8 +1,10 @@
 package org.locationtech.udig.catalog.util;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
+import java.text.MessageFormat;
 import java.util.List;
 
 import org.junit.Assume;
@@ -22,11 +24,20 @@ public final class CatalogTestUtils {
     public static void assumeNoConnectionException(URL url, int timeoutInMS) {
         try {
             URLConnection connection = url.openConnection();
+            if (connection instanceof HttpURLConnection) {
+                HttpURLConnection httpConnection = ((HttpURLConnection)connection);
+                if (HttpURLConnection.HTTP_OK != httpConnection.getResponseCode()) {
+                    throw new IOException("Responsecode != 200",
+                            new Throwable(MessageFormat.format("HTTP {0} : {1}",
+                                    httpConnection.getResponseCode(),
+                                    httpConnection.getResponseMessage())));
+                }
+            }
             connection.setConnectTimeout(timeoutInMS);
             connection.connect();
-        } catch (IOException e) {
-            e.printStackTrace();
-            Assume.assumeNoException(e);
+        } catch (Throwable e) {
+            Assume.assumeNoException("unable to connect to, skipping test", e);
+            throw new RuntimeException(e);
         }
     }
     

--- a/plugins/org.locationtech.udig.issues.test/pom.xml
+++ b/plugins/org.locationtech.udig.issues.test/pom.xml
@@ -20,8 +20,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
             </plugin>
 

--- a/plugins/org.locationtech.udig.libs.tests/pom.xml
+++ b/plugins/org.locationtech.udig.libs.tests/pom.xml
@@ -20,8 +20,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
             </plugin>
 

--- a/plugins/org.locationtech.udig.libs.tests/src/org/locationtech/udig/libs/tests/GeoToolsTest.java
+++ b/plugins/org.locationtech.udig.libs.tests/src/org/locationtech/udig/libs/tests/GeoToolsTest.java
@@ -57,8 +57,8 @@ public class GeoToolsTest {
     @Test
     public void testGeoTools(){
          Version version = GeoTools.getVersion();
-         assertEquals( 14, version.getMajor() );
-         assertTrue( version.getMinor().toString().startsWith("1") );
+         assertEquals( 19, version.getMajor() );
+         assertEquals( 0, version.getMinor() );
     }
 
     @Ignore("FIXME: due to migration to batik bundle from Orbit")

--- a/plugins/org.locationtech.udig.location.test/pom.xml
+++ b/plugins/org.locationtech.udig.location.test/pom.xml
@@ -20,8 +20,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
             </plugin>
 

--- a/plugins/org.locationtech.udig.project.tests.ui/pom.xml
+++ b/plugins/org.locationtech.udig.project.tests.ui/pom.xml
@@ -20,8 +20,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
             </plugin>
 

--- a/plugins/org.locationtech.udig.project.tests/pom.xml
+++ b/plugins/org.locationtech.udig.project.tests/pom.xml
@@ -20,8 +20,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
             </plugin>
 

--- a/plugins/org.locationtech.udig.render.feature.basic.test/pom.xml
+++ b/plugins/org.locationtech.udig.render.feature.basic.test/pom.xml
@@ -20,8 +20,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
             </plugin>
 

--- a/plugins/org.locationtech.udig.render.wms.basic.test/pom.xml
+++ b/plugins/org.locationtech.udig.render.wms.basic.test/pom.xml
@@ -20,8 +20,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
             </plugin>
 

--- a/plugins/org.locationtech.udig.style.tests/pom.xml
+++ b/plugins/org.locationtech.udig.style.tests/pom.xml
@@ -20,8 +20,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
             </plugin>
 

--- a/plugins/org.locationtech.udig.tests.catalog.wmt/pom.xml
+++ b/plugins/org.locationtech.udig.tests.catalog.wmt/pom.xml
@@ -20,8 +20,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
             </plugin>
 

--- a/plugins/org.locationtech.udig.tests.info/pom.xml
+++ b/plugins/org.locationtech.udig.tests.info/pom.xml
@@ -20,8 +20,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
             </plugin>
 

--- a/plugins/org.locationtech.udig.tool.default.tests/pom.xml
+++ b/plugins/org.locationtech.udig.tool.default.tests/pom.xml
@@ -20,8 +20,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
             </plugin>
 

--- a/plugins/org.locationtech.udig.tool.edit.tests/pom.xml
+++ b/plugins/org.locationtech.udig.tool.edit.tests/pom.xml
@@ -20,8 +20,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
             </plugin>
 

--- a/plugins/org.locationtech.udig.tool.select.tests/pom.xml
+++ b/plugins/org.locationtech.udig.tool.select.tests/pom.xml
@@ -20,8 +20,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
             </plugin>
 

--- a/plugins/org.locationtech.udig.tools.tests/pom.xml
+++ b/plugins/org.locationtech.udig.tools.tests/pom.xml
@@ -17,8 +17,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
             </plugin>
 

--- a/plugins/org.locationtech.udig.ui.tests/pom.xml
+++ b/plugins/org.locationtech.udig.ui.tests/pom.xml
@@ -18,8 +18,7 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
-                   <testRuntime>p2Installed</testRuntime>
-                   <application>org.locationtech.udig.ui.application</application>
+                    <application>org.locationtech.udig.ui.application</application>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
addressed several issues regarding test and test execution:
* fixes GeoTools version test
* fixes test execution problems (p2installed)
* optimized Assumtion regarding connections, and checks http return code as well